### PR TITLE
sale-commit-v1

### DIFF
--- a/src/css/sale.css
+++ b/src/css/sale.css
@@ -126,6 +126,9 @@
     border-radius: 8px;
     color: rgba(251, 251, 251, 1);
 }
+.sale-promo-tag-p{
+    font-size: 12px;
+  }
 @media screen and (min-width: 768px){
     .sale{
         padding-top: 40px;
@@ -184,9 +187,9 @@
         margin-right: 186px;
         margin-top: 40px;
     }
-    .sale-promo-tag{
-        font-size: 14px;
-        line-height: 18px;
+    .sale-promo-tag-p{
+      font-size: 14px;
+      line-height: 18px;
     }
 }
 @media screen and (min-width: 1280px){

--- a/src/partials/sale.html
+++ b/src/partials/sale.html
@@ -57,12 +57,12 @@
           The Garmin MARQ Commander Gen 2 Carbon Edition is a modern smartwatch for adventurers that takes materials and features to the next level. The body of the watch is made of very durable Fused Carbon Fiber material and has a precise AMOLED touch screen. The sensitive touch screen is complemented by buttons that can be used in any conditions.
         </p>
         <ul class="sale-promo-tags">
-          <li class="sale-promo-tag"><p>Fused carbon fiber</p></li>
-          <li class="sale-promo-tag"><p>Grade-5 Titanium</p></li>
-          <li class="sale-promo-tag"><p>Athlete</p></li>
-          <li class="sale-promo-tag"><p>Golfer</p></li>
-          <li class="sale-promo-tag"><p>Commander</p></li>
-          <li class="sale-promo-tag"><p>Adventurer</p></li>
+          <li class="sale-promo-tag"><p class="sale-promo-tag-p">Fused carbon fiber</p></li>
+          <li class="sale-promo-tag"><p class="sale-promo-tag-p">Grade-5 Titanium</p></li>
+          <li class="sale-promo-tag"><p class="sale-promo-tag-p">Athlete</p></li>
+          <li class="sale-promo-tag"><p class="sale-promo-tag-p">Golfer</p></li>
+          <li class="sale-promo-tag"><p class="sale-promo-tag-p">Commander</p></li>
+          <li class="sale-promo-tag"><p class="sale-promo-tag-p">Adventurer</p></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Додав клас sale-promo-tags-p(60-65 строка HTML), Видалив в css .sale-promo-tags для планшетної версії. Для планшетної версії додав стилі для .sale-promo-tag-p(190 строка).